### PR TITLE
Add setup for subdirectory

### DIFF
--- a/docs/fundamentals/customer-communication.mdx
+++ b/docs/fundamentals/customer-communication.mdx
@@ -11,7 +11,7 @@ In addition, even non-sales people (Product Manager, Designer, Developer, etc.) 
 
 ## Inbox
 
-![Inbox](/images/fundamentals/inbox.png)
+![Inbox](/docs/images/fundamentals/inbox.png)
 
 Relate's Inbox is the source of truth for customer communication and history. With Inbox, you can manage your customer communication without missing anything.
 
@@ -39,7 +39,7 @@ Not all emails can be accessed in Relate App. Only the emails registered as cont
 
 ## Communication Timeline
 
-![Communication Timeline](/images/fundamentals/communication-timeline.png)
+![Communication Timeline](/docs/images/fundamentals/communication-timeline.png)
 
 When you go into the Lead Detail page, you can find all your customer interaction history in a timeline format. You can also leave internal comments on the email threads and sales notes found in the timeline.
 
@@ -61,7 +61,7 @@ If you do not see any email coming in after adding the contact's email, please c
 
 ## Note
 
-![Note](/images/fundamentals/note.png)
+![Note](/docs/images/fundamentals/note.png)
 
 You can add and share meeting notes and various updates about customers on the Lead Detail page.
 

--- a/docs/fundamentals/deal-pipeline.mdx
+++ b/docs/fundamentals/deal-pipeline.mdx
@@ -3,11 +3,11 @@ title: "Deal Pipeline"
 description: "Deal Pipeline lets you track and manage all your sales opportunities in a single, bird-eye-view. This is where you'll track all pending deals and their owners, pending value ($), and their statuses."
 ---
 
-![Deal Pipeline](/images/fundamentals/deal-pipeline.png)
+![Deal Pipeline](/docs/images/fundamentals/deal-pipeline.png)
 
 ## Pipeline Management
 
-![Pipeline Management](/images/fundamentals/pipeline-management.png)
+![Pipeline Management](/docs/images/fundamentals/pipeline-management.png)
 
 You can easily drag & drop each deal card to reflect updates.
 
@@ -27,7 +27,7 @@ When you scroll over the upper right corner of a deal card, two buttons appear a
 
 You can also come back to the Deal Pipeline page directly from the Lead Detail Page by clicking the button on the top right corner.
 
-![Go to contacts page](/images/fundamentals/deal-connection.png)
+![Go to contacts page](/docs/images/fundamentals/deal-connection.png)
 
 ---
 
@@ -39,13 +39,13 @@ You can also come back to the Deal Pipeline page directly from the Lead Detail P
 
 You can create and manage multiple deals for each Lead (Customers).
 
-![What is a deal](/images/fundamentals/what-is-deal.png)
+![What is a deal](/docs/images/fundamentals/what-is-deal.png)
 
 When you have multiple deals, it will be shown like this in the Lead Detail Page.
 
 ### How to Add Deals
 
-![Adding a deal](/images/fundamentals/how-to-add-deals.png)
+![Adding a deal](/docs/images/fundamentals/how-to-add-deals.png)
 
 There are 3 ways to add a deal.
 
@@ -81,11 +81,11 @@ If you go down to the bottom of this page, then you can find information about c
 
 You can customize deal statuses to fit your team's sales process.
 
-![Manage deal status](/images/fundamentals/manage-deal-status.png)
+![Manage deal status](/docs/images/fundamentals/manage-deal-status.png)
 
 To manage the Deal Status, click Workspace ellipsis (⋅⋅⋅) in the Relate app, and click `Manage deal statuses` from the menu that appears.
 
-![Manage deal statuses](/images/fundamentals/manage-deal-statuses.png)
+![Manage deal statuses](/docs/images/fundamentals/manage-deal-statuses.png)
 
 You can change the order by clicking the arrows, and you can change the name of each status by clicking `Edit`.
 
@@ -113,7 +113,7 @@ A good example would be to look at the deals managed by each sales rep or look a
 
 - `Updated at` \+ `is after` \+ This Monday
 
-![Deal filtering](/images/fundamentals/deal-filtering.png)
+![Deal filtering](/docs/images/fundamentals/deal-filtering.png)
 
 ### Applying Multiple Filters
 
@@ -125,17 +125,17 @@ When applying more than 1 filter, you can apply one of the two conditions: And /
 
 ## Deal Custom Field
 
-![Deal custom field](/images/fundamentals/deal-custom-field.png)
+![Deal custom field](/docs/images/fundamentals/deal-custom-field.png)
 
 As shown in the screenshot above, you can add various types of custom fields on the Deal page.
 
 You can find `Manage custom fields` menu when you scroll your mouse cursor on your Workspace name. You will see Workspace ellipsis (⋅⋅⋅) in the Relate app. (See screenshot below)
 
-![Deal custom field](/images/fundamentals/manage-custom-fields.png)
+![Deal custom field](/docs/images/fundamentals/manage-custom-fields.png)
 
 Below is the example of setting Custom Fields.
 
-![Deal custom field](/images/fundamentals/setting-custom-fields.png)
+![Deal custom field](/docs/images/fundamentals/setting-custom-fields.png)
 
 ### Types of Custom Field
 

--- a/docs/fundamentals/leads-and-contacts.mdx
+++ b/docs/fundamentals/leads-and-contacts.mdx
@@ -5,13 +5,13 @@ description: "Relate's powerful lead & contact management capabilities let you m
 
 ## Add Lead/Contact
 
-![Add Lead](/images/fundamentals/add-lead.png)
+![Add Lead](/docs/images/fundamentals/add-lead.png)
 
 Adding new leads and contacts works the same way. First, you can create a new lead/contact by pressing the `+Lead` (or `+Contact`) button on the Lead page (or Contact page) as shown in the screenshot above.
 
 ### Add Contact
 
-![Add Contact](/images/fundamentals/add-contact.png)
+![Add Contact](/docs/images/fundamentals/add-contact.png)
 
 There are several ways to create a Contact.
 
@@ -21,13 +21,13 @@ There are several ways to create a Contact.
 
 - Click Contacts in the left menu, and then press `+Contact` to add a new Contact
 
-![Add Contact Data](/images/fundamentals/add-contact-data.png)
+![Add Contact Data](/docs/images/fundamentals/add-contact-data.png)
 
 You can add contact while adding a new lead by clicking "Add contact data"
 
 ## Add Lead/Contact Custom Field
 
-![Add Contact Custom Field](/images/fundamentals/add-contact-custom-field.png)
+![Add Contact Custom Field](/docs/images/fundamentals/add-contact-custom-field.png)
 
 As shown in the screenshot above, you can add various types of custom fields to the Lead and Contact lists.
 
@@ -39,11 +39,11 @@ Alternatively, you can go to [https://app.relate.so/](https://app.relate.so/) to
 
 </Note>
 
-![Manage Custom Fields](/images/fundamentals/manage-custom-fields.png)
+![Manage Custom Fields](/docs/images/fundamentals/manage-custom-fields.png)
 
 Below is a screenshot example of managing Custom Fields.
 
-![Manage Custom Fields in Company](/images/fundamentals/manage-custom-fields-in-company.png)
+![Manage Custom Fields in Company](/docs/images/fundamentals/manage-custom-fields-in-company.png)
 
 ### Types of Custom Field
 
@@ -72,13 +72,13 @@ To check Custom Field modifications reflected immediately, relaunch the Relate a
 
 ## Lead/Contact Filtering
 
-![Lead Contact Filtering](/images/fundamentals/lead-contact-filtering.png)
+![Lead Contact Filtering](/docs/images/fundamentals/lead-contact-filtering.png)
 
 \`Filter\` lets you (literally) add filters to your Lead or Contacts list.
 
 For example, you can create a list of leads that you should follow up on this week. To create this, you can apply a filter `Updated at` \+ `is after` \+ `Date`.
 
-![Filter data](/images/fundamentals/filter-date.png)
+![Filter data](/docs/images/fundamentals/filter-date.png)
 
 #### Applying Multiple Filters
 
@@ -90,7 +90,7 @@ When applying more than 1 filter, you can apply one of the two conditions: And /
 
 ## Customize Columns on Lead/Contact Page
 
-![Customize Columns](/images/fundamentals/customize-columns.png)
+![Customize Columns](/docs/images/fundamentals/customize-columns.png)
 
 The Lead/Contact list can be customized by clicking the `Customize columns` button at the top right corner.
 

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -1,8 +1,9 @@
 {
   "name": "Relate",
+  "basePath": "/docs",
   "logo": {
-    "light": "/logo/light.svg",
-    "dark": "/logo/dark.svg"
+    "light": "/docs/logo/light.svg",
+    "dark": "/docs/logo/dark.svg"
   },
   "favicon": "/favicon.png",
   "colors": {

--- a/docs/setup/email-integration-google-outlook-etc.mdx
+++ b/docs/setup/email-integration-google-outlook-etc.mdx
@@ -7,7 +7,7 @@ description: "This guide will help you integrate your email service to Relate."
 
 To integrate your email with Relate, go to the [Email Integration](https://app.relate.so/services) page in the Relate Admin.
 
-![Connect email](/images/setup/connect-email.png)
+![Connect email](/docs/images/setup/connect-email.png)
 
 Click the **Connect** button, enter the email address you want to connect to, and select the email service you use (Google, Office365, Outlook Exchange, and all other services, select Other)
 
@@ -17,7 +17,7 @@ Click the **Connect** button, enter the email address you want to connect to, an
 
 Please follow the procedure provided on each email service link page to complete. Then, just follow the **2\. Creating Connections for Each Workspace.**
 
-![Google Account](/images/setup/google-account-access.png)
+![Google Account](/docs/images/setup/google-account-access.png)
 
 <Check>
   💡 If you see a **warning message**, please check if you have registered
@@ -35,7 +35,7 @@ Please follow the procedure provided on each email service link page to complete
 
 Please enter your email address and password to connect as shown below.
 
-![Sign in](/images/setup/sign-in.png)
+![Sign in](/docs/images/setup/sign-in.png)
 
 #### **1.1.2.** Entering IMAP/SMTP information
 
@@ -43,13 +43,13 @@ IMAP and SMPT host addresses and Port/SSL numbers have unique values for each em
 
 In this guide, IMAP/SMTP information of NAVER Works is used.
 
-![IMAP/SMTP](/images/setup/imap-smtp-info.png)
+![IMAP/SMTP](/docs/images/setup/imap-smtp-info.png)
 
 After entering the information, click the **Sign in** button to complete the connection.
 
 If it is changed to **Connected** as shown below on the Relate page, the email linkage is successful. Now, you need to create a Connection so that you can connect the email to each workspace. **2\. Go to Creating Connections for Each Workspace.**
 
-![Email Connect](/images/setup/email-connected.png)
+![Email Connect](/docs/images/setup/email-connected.png)
 
 <Note>
   💡 If Two-factor Authentication (2FA or MFA) is currently set in your email
@@ -60,11 +60,11 @@ If it is changed to **Connected** as shown below on the Relate page, the email l
 
 To connect your email service to a new Workspace, select the workspace you want to connect to, and click the **Create Connection** button.
 
-![Creating Connection](/images/setup/creating-connections-workspace.png)
+![Creating Connection](/docs/images/setup/creating-connections-workspace.png)
 
 When a Connection is created, you can see that a Connection has been created in the **Connected users** table as shown below.
 
-![Connected Users](/images/setup/connected-users.png)
+![Connected Users](/docs/images/setup/connected-users.png)
 
 Email integration is now complete. Return to the Relate app and register your customers' email address within Lead/contact, and you will see emails sent to and received from that email address.
 

--- a/docs/setup/register-google-api-allowlist.mdx
+++ b/docs/setup/register-google-api-allowlist.mdx
@@ -17,11 +17,11 @@ Make sure you are a Google Workspace Admin. Only admins can add applications to 
 
 1.2. Find **Directory > Users** page on the left side, and click your name that is shown on the right. See below screenshot.
 
-![Directory Users](/images/setup/directory-users.png)
+![Directory Users](/docs/images/setup/directory-users.png)
 
 1.3. Under `Admin roles and privileges tab`, check if your role is a **Super Admin.**
 
-![Super Admin](/images/setup/super-admin.png)
+![Super Admin](/docs/images/setup/super-admin.png)
 
 1.4. If you are a Super Admin, you can proceed to i**i) Add Relate to API allowlist.**
 
@@ -31,28 +31,28 @@ Make sure you are a Google Workspace Admin. Only admins can add applications to 
 
 2.1. On the left navigation menu, find **Security > Access and Data Control > API controls** page. If you do not see the page, click `Show more` at the bottom to view additional pages.
 
-![Add Relate to API Allowlist](/images/setup/add-relate-to-api-allowlist.png)
+![Add Relate to API Allowlist](/docs/images/setup/add-relate-to-api-allowlist.png)
 
 2.2.In API controls page, under **App access control** tab, find and click `MANAGE THIRD-PARTY APP ACCESS` link.
 
-![Manage Third Party App Access](/images/setup/app-access-control.png)
+![Manage Third Party App Access](/docs/images/setup/app-access-control.png)
 
 2.3. In the **Configured apps** table, click `Add app` then select `OAuth App Name or Client ID`.
 
-![OAuth App name](/images/setup/oauth-app-name.png)
+![OAuth App name](/docs/images/setup/oauth-app-name.png)
 
 2.4. Copy Relate client ID: `896496487864-0bq252frk3u80q051aucqabr6t92jr7c` and paste it into the search bar, you will be able to find Relate app. Select Relate app to proceed.
 
-![Copy relate client ID](/images/setup/copy-relate-client-id.png)
+![Copy relate client ID](/docs/images/setup/copy-relate-client-id.png)
 
 2.5. Check OAuth Client ID and click `SELECT`.
 
-![SELECT](/images/setup/select.png)
+![SELECT](/docs/images/setup/select.png)
 
 2.6. Select **Trusted: Can access all Google services**, then click `CONFIGURE` to proceed.
 
-![CONFIGURE](/images/setup/configure.png)
+![CONFIGURE](/docs/images/setup/configure.png)
 
 2.7. If you see an identical list shown below on your screen, you have successfully completed adding Relate to your Google Workspace allowlist. Congratulations! 🙌
 
-![Check Identical list](/images/setup/identical-list.png)
+![Check Identical list](/docs/images/setup/identical-list.png)

--- a/docs/setup/zapier-integration/how-to-integrate-with-zapier.mdx
+++ b/docs/setup/zapier-integration/how-to-integrate-with-zapier.mdx
@@ -21,7 +21,7 @@ title: "How to Integrate with Zapier"
 
 First, find and select Relate and another application you want to connect it with.
 
-![Connect Relate to Zapier](/images/setup/zapier/connect-relate-to-zapier.png)
+![Connect Relate to Zapier](/docs/images/setup/zapier/connect-relate-to-zapier.png)
 
 ### 2. Create a Zap
 
@@ -33,27 +33,27 @@ In this guide, we will cover a use case that automatically creates a lead in Rel
 
 First, search for Google Forms in the Trigger menu.
 
-![Add Trigger](/images/setup/zapier/add-trigger.png)
+![Add Trigger](/docs/images/setup/zapier/add-trigger.png)
 
 Select "New Response in Spreadsheet" as a condition to trigger the Zap.
 
-![New Response In Spreadsheet](/images/setup/zapier/new-response-in-spreadsheet.png)
+![New Response In Spreadsheet](/docs/images/setup/zapier/new-response-in-spreadsheet.png)
 
 Sign into Google Forms and allow Zapier Integration.
 
-![Sign into Google forms](/images/setup/zapier/sign-into-google-forms.png)
+![Sign into Google forms](/docs/images/setup/zapier/sign-into-google-forms.png)
 
-![Sign into Google forms part two](/images/setup/zapier/sign-into-google-forms-2.png)
+![Sign into Google forms part two](/docs/images/setup/zapier/sign-into-google-forms-2.png)
 
 Select a form to connect with Relate.
 
-![Select a form to connect](/images/setup/zapier/select-a-form-to-connect.png)
+![Select a form to connect](/docs/images/setup/zapier/select-a-form-to-connect.png)
 
 Select the worksheet in the same way.
 
 Check if the data is correct through `Test trigger`.
 
-![Test trigger](/images/setup/zapier/test-trigger.png)
+![Test trigger](/docs/images/setup/zapier/test-trigger.png)
 
 If you see ✅ on the Trigger tab after clicking `Continue`, it means that the connection was successful.
 
@@ -61,27 +61,27 @@ If you see ✅ on the Trigger tab after clicking `Continue`, it means that the c
 
 Click the Action tab and search for Relate. Make sure to select \`Relate (2.0.0) Latest\`
 
-![Settling Action](/images/setup/zapier/settling-action.png)
+![Settling Action](/docs/images/setup/zapier/settling-action.png)
 
 Select Generate Lead & Contact.
 
-![Select generate lead and contact](/images/setup/zapier/select-generate-lead-and-contact.png)
+![Select generate lead and contact](/docs/images/setup/zapier/select-generate-lead-and-contact.png)
 
 At this time, a new window will appear asking you to enter the API Key.
 
 Now, go to API Page in the [Relate settings page](https://app.relate.so/) of the workspace. Select `Manage API Keys`.
 
-![Manage API Keys](/images/setup/zapier/manage-api-keys.png)
+![Manage API Keys](/docs/images/setup/zapier/manage-api-keys.png)
 
-![Generate API Keys](/images/setup/zapier/generate-api-key.png)
+![Generate API Keys](/docs/images/setup/zapier/generate-api-key.png)
 
 Click `Generate API Key` to generate a new API Key. Once you store the key, it will not be shown again for security purposes. So, please copy the key before saving it.
 
-![Copy Key](/images/setup/zapier/copy-key.png)
+![Copy Key](/docs/images/setup/zapier/copy-key.png)
 
 Paste the copied key into the API key input window that appears from Zapier and continue to complete the Relate API connection.
 
-![Paste Key](/images/setup/zapier/paste-key.png)
+![Paste Key](/docs/images/setup/zapier/paste-key.png)
 
 Match the information from Google Form to the data fields in Relate Lead/Contact/Deal/Note as shown below.
 
@@ -99,16 +99,16 @@ Also, since the newly created notes are shown in the Inbox, it will become a rem
 
 If you do not include any data for the deals, Deal will not be created. If you want to create a Deal when a new Lead and a Contact are created, you can enter information in the Deal-related fields (Example: Deal Assignee, Deal Status, etc.)
 
-![Deals data](/images/setup/zapier/deals-data.png)
+![Deals data](/docs/images/setup/zapier/deals-data.png)
 
-![Deals data part two](/images/setup/zapier/deals-data-2.png)
+![Deals data part two](/docs/images/setup/zapier/deals-data-2.png)
 
 If you click `Continue`, you will see a step where you can test action. The test sends the actual data to the Relate, so if necessary, you can delete it later.
 
 If the test is successful, you can check the data in Relate.
 
-![Check data in relate](/images/setup/zapier/check-data-relate.png)
+![Check data in relate](/docs/images/setup/zapier/check-data-relate.png)
 
-![Publish Zap](/images/setup/zapier/publish-zap.png)
+![Publish Zap](/docs/images/setup/zapier/publish-zap.png)
 
 Now press `Publish Zap` to enable Zap. Finally, in the top left, you can change the title of Zap to make it more legible.

--- a/docs/setup/zapier-integration/what-is-zapier.mdx
+++ b/docs/setup/zapier-integration/what-is-zapier.mdx
@@ -5,7 +5,7 @@ description: "Introducing Zapier and Relate integration, which automatically lin
 
 ### Zapier 101
 
-![Zapier 101](/images/setup/zapier/zapier-101.png)
+![Zapier 101](/docs/images/setup/zapier/zapier-101.png)
 
 Zapier is a tool that can easily integrate SaaS applications without coding. It supports 5 free integrations (Zap), and after 5, you can use up to 20 by paying $19.99 per month.
 
@@ -17,23 +17,23 @@ For example, if a lead is newly created through the Facebook Ad (Trigger), a mes
 
 #### Trigger Example (Source: Zapier)
 
-![Trigger Example](/images/setup/zapier/trigger-example.png)
+![Trigger Example](/docs/images/setup/zapier/trigger-example.png)
 
 #### Action Example (Source: Zapier)
 
-![Action Example](/images/setup/zapier/action-example.png)
+![Action Example](/docs/images/setup/zapier/action-example.png)
 
 ### Multi-Step
 
 Zapier's multi-step provides even complex IF/THEN functions.
 
-![Multi-Step](/images/setup/zapier/multi-step.png)
+![Multi-Step](/docs/images/setup/zapier/multi-step.png)
 
 ### Additional Logic
 
 Zapier also supports various logics such as delay, filter, format, sending email, etc.
 
-![Additional Logic](/images/setup/zapier/additional-logic.png)
+![Additional Logic](/docs/images/setup/zapier/additional-logic.png)
 
 ### Useful Links
 


### PR DESCRIPTION
# Summary

This PR adds support for the subdirectory that, combined with Cloudfare Workers, will enable for the documentation to be hosted at `relate.so/docs`.

**Before merging in this branch**, make sure that the `DOCS_URL` in the Cloudfare worker function is updated to

```javascript
const DOCS_URL = "relateso.mintlify.com" // instead of relate.mintlify.com (what it is right now)
```

# Breaking changes

After merging this branch, `docs.relate.so` will no longer work as normal. You can still view the content at `docs.relate.so/docs`, but just the base url will display a 404 page.